### PR TITLE
Update rails.inc to remove console error spam about out of range sprite glow proxy property

### DIFF
--- a/tf/addons/sourcemod/scripting/objects/rails.inc
+++ b/tf/addons/sourcemod/scripting/objects/rails.inc
@@ -295,7 +295,7 @@ void CreateRailSprites(float vecOrigin[3], int iColor[3] = {255, 0, 0})
 	SetEdictFlags(iEntity, FL_EDICT_ALWAYS);
 
 	SetEntityRenderMode(iEntity, RENDER_WORLDGLOW);  
-	DispatchKeyValue(iEntity, "GlowProxySize", "5000");
+	DispatchKeyValue(iEntity, "GlowProxySize", "64");
 	DispatchKeyValue(iEntity, "renderamt", "255"); 
 	DispatchKeyValue(iEntity, "framerate", "10.0"); 
 	DispatchKeyValue(iEntity, "scale", "100.0");


### PR DESCRIPTION
Stop console spam about glow proxy geometry size being clamped to 64.
`DataTable warning: env_sprite: Out-of-range value (5000.000000/64.000000) in SendPropFloat 'm_flGlowProxySize', clamping.`