### PR TITLE
Fixes

### DIFF
--- a/tf/addons/sourcemod/scripting/movements/roll.inc
+++ b/tf/addons/sourcemod/scripting/movements/roll.inc
@@ -108,7 +108,7 @@ methodmap CPFRollHandler
 			return false;
 		}
 		
-		if (vecVelocity[2] < -1050 && CPFStateController.Get(iClient) != State_Roll && CPFStateController.Get(iClient) != State_Locked)
+		if (vecVelocity[2] < -1050 && !CPFSpeedController.GetFallDeathImmunity(iClient) && CPFStateController.Get(iClient) != State_Roll && CPFStateController.Get(iClient) != State_Locked)
 		{
 			const float STUN_DURATION = 3.0;
 			

--- a/tf/addons/sourcemod/scripting/parkourfortress.sp
+++ b/tf/addons/sourcemod/scripting/parkourfortress.sp
@@ -1612,7 +1612,12 @@ public Action OnTakeDamage(int iClient, int &iAttacker, int &iInflictor, float &
 		}
 		flNewSpeed = CPFSpeedController.GetSpeed(iClient, true) - (flDamage * 0.5);
 	}
-
+	
+	if (!g_cvarPvP.BoolValue && IsValidClient(iAttacker))
+	{
+		eAction = Plugin_Handled;
+	}
+	
 	if (eAction != Plugin_Handled)
 	{
 		CPFSpeedController.ValidateSpeed(iClient, flNewSpeed, .flMaxClampAt = MINIMUM_SPEED_PENALTY, .flMaxClampTo = MINIMUM_SPEED_PENALTY);


### PR DESCRIPTION
roll.inc
-While in a no fall damage trigger, players can no longer get stunned from falling

parkourfortress.sp
-While PvP is not enabled, hitting a player will no longer reset their speed to SPEED_BASE of 250.0