### PR TITLE
Various Fixes

### DIFF
--- a/tf/addons/sourcemod/scripting/parkourfortress.sp
+++ b/tf/addons/sourcemod/scripting/parkourfortress.sp
@@ -961,6 +961,7 @@ void InitOther()
 	SDKHookClassname("trigger_multiple", SDKHook_StartTouch, OnStartTouchTrigger);
 	SDKHookClassname("trigger_catapult", SDKHook_StartTouch, OnStartTouchTrigger);
 	SDKHookClassname("trigger_push", SDKHook_StartTouch, OnStartTouchTrigger);
+	SDKHookClassname("trigger_hurt", SDKHook_StartTouch, OnStartTouchTrigger);
 	
 	SDKHookClassname("trigger_multiple", SDKHook_EndTouch, OnEndTouchTrigger);
 	
@@ -1636,6 +1637,8 @@ public void OnPlayerDeath(Event event, const char[] name, bool dontBroadcast)
 	CPFSoundController.StopAllSounds(client);
 	
 	CPFStateController.Set(client, State_None);
+	
+	CPFStateController.RemoveFlags(client, SF_BEINGHEALED);
 	
 	CPFViewController.Kill(client);
 }

--- a/tf/addons/sourcemod/scripting/parkourfortress.sp
+++ b/tf/addons/sourcemod/scripting/parkourfortress.sp
@@ -1078,7 +1078,7 @@ public void Tutorial_OnGetPlayerStage(int iClient, TutorialStage eStage)
 
 public void GiveFists(int iClient)
 {
-	int iWeapon = TF2_CreateAndEquipWeapon(iClient, WEAPON_FISTS, (g_cvarPvP.BoolValue) ? "1 ; 0.80" : "1 ; 0.00");
+	int iWeapon = TF2_CreateAndEquipWeapon(iClient, WEAPON_FISTS, "1 ; 0.80");
 	SetCollisionGroup(iWeapon, COLLISION_GROUP_NONE);
 }
 


### PR DESCRIPTION
Allows trigger_hurt brush entities to have special trigger events (nofalldamage, etc.)
Removes fists damage penalty in non-pvp scenarios as player damage as its returned as plugin_handled as of the previous PR
Fixes regen not working after getting killed by a trigger_hurt by removing the SF_BEINGHEALED flag on death