### PR TITLE
Added Movetype Check To The "lockcontrols" Trigger

### DIFF
--- a/tf/addons/sourcemod/scripting/parkourfortress.sp
+++ b/tf/addons/sourcemod/scripting/parkourfortress.sp
@@ -1626,14 +1626,20 @@ public Action OnStartTouchTrigger(int iEnt, int iClient)
 	
 	if (StrEqual("lockcontrols", strTargetname))
 	{
+		if(GetEntityMoveType(iClient) == MOVETYPE_NOCLIP)
+			return Plugin_Continue;
+		
 		CPFStateController.ResetClient(iClient);
 		
 		CPFStateController.Set(iClient, State_Locked);
 		SetEntityFlags(iClient, GetEntityFlags(iClient)|FL_ATCONTROLS);
 		return Plugin_Continue;
 	}
-	else if (StrEqual("unlockcontrols", strTargetname) && eState == State_Locked)
+	else if (StrEqual("unlockcontrols", strTargetname))
 	{
+		if(eState != State_Locked)
+			return Plugin_Continue;
+		
 		CPFStateController.ResetClient(iClient);
 		return Plugin_Continue;
 	}


### PR DESCRIPTION
This prevents no-clipping clients from being put into a locked state via the "lockcontrols" trigger. I also moved the eState == State_Locked check inside the "unlockcontrols" nest and inverted it because once StrEqual("unlockcontrols", strTargetname) is true, there's no need to run any code outside the nest.