### PR TITLE
Fix SourceMod 1.13 compile errors

### DIFF
--- a/tf/addons/sourcemod/scripting/parkourfortress.sp
+++ b/tf/addons/sourcemod/scripting/parkourfortress.sp
@@ -756,11 +756,6 @@ void InitSDK()
 	if (hGameData == null)
 		SetFailState("Failed to load gamedata parkourdata.txt");
 
-	StartPrepSDKCall(SDKCall_Raw);
-	PrepSDKCall_SetFromConf(hGameData, SDKConf_Virtual, "CBaseEntity::GetBaseEntity");
-	PrepSDKCall_SetReturnInfo(SDKType_CBaseEntity, SDKPass_Pointer);
-	g_hSDKGetBaseEntity = EndPrepSDKCall();
-
 	StartPrepSDKCall(SDKCall_Player);
 	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "CTFPlayer::GetMaxAmmo");
 	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);

--- a/tf/addons/sourcemod/scripting/parkourfortress/movements/grindable-rail.sp
+++ b/tf/addons/sourcemod/scripting/parkourfortress/movements/grindable-rail.sp
@@ -701,7 +701,7 @@ methodmap CPFRailHandler
 	 * Input: Runs on every frame.
 	 * Output: Players who meet the criteria for it will be mounted to rails.
 	 */
-	public static CPFRail OnGameFrame()
+	public static void OnGameFrame()
 	{
 		const float CLOSEST_POINT_DECREMENT = 15.0;
 		const float ORIGIN_HEIGHT_ADJUSTMENT = 41.0;

--- a/tf/addons/sourcemod/scripting/parkourfortress/pfstate.sp
+++ b/tf/addons/sourcemod/scripting/parkourfortress/pfstate.sp
@@ -162,7 +162,7 @@ methodmap CPFStateController
 		return g_eStateInfo[iClient].ButtonsInterrupted;
 	}
 
-	public static int SetCooldown(int iClient, PFState eState, float flLength)
+	public static void SetCooldown(int iClient, PFState eState, float flLength)
 	{
 		g_bOnCooldown[eState][iClient] = true;
 		DataPack hData = new DataPack();

--- a/tf/addons/sourcemod/scripting/parkourfortress/shareddefs.sp
+++ b/tf/addons/sourcemod/scripting/parkourfortress/shareddefs.sp
@@ -24,7 +24,6 @@ bool g_bTutorialFetched[MAXPLAYERS + 1];
 Handle g_hSDKEquipWearable;
 Handle g_hSDKRemoveWearable;
 Handle g_hSDKGetEquippedWearable;
-Handle g_hSDKGetBaseEntity;
 
 Handle g_hSDKGetMaxAmmo;
 Handle g_hHookSetWinningTeam;
@@ -184,26 +183,6 @@ enum TakeDamage_t
 	DAMAGE_YES,
 	DAMAGE_AIM,
 };
-
-enum struct CTFGameMovementOffsets
-{
-	int player;
-}
-
-CTFGameMovementOffsets offsets;
-
-methodmap CGameMovement
-{
-	public CGameMovement(Address pGameMovement)
-	{
-		return view_as<CGameMovement>(pGameMovement);
-	}
-	
-	property int player
-	{
-		public get() { return SDKCall(g_hSDKGetBaseEntity, LoadFromAddress(view_as<Address>(this) + view_as<Address>(offsets.player), NumberType_Int32)); }
-	}
-}
 
 #if !defined _PF_INCLUDED
 stock bool IsValidClient(int iClient)


### PR DESCRIPTION
Fixes #64.

Makes the plugin compile under SourceMod 1.13 while keeping it building under 1.12, so the existing `build.yml` workflow (which resolves the `stable` channel, currently 1.12) is unaffected.

## What was broken

7 errors, from two independent causes.

**Stricter return checking.** 1.13 enforces that a function declared with a non-`void` return type actually returns a value. Two methodmap functions declared a return type they never used, and every caller discarded the result anyway.

**`Address` widened to 64-bit.** A methodmap value is a 32-bit cell, so `view_as` between `Address` and a methodmap type is no longer legal in either direction. This broke the `CGameMovement` methodmap; the two `error 400`s at `shareddefs.sp:197` and `:203` were cascades of the `error 460`s at `:199` and `:204`.

## Changes

Two commits, one per cause.

### `71cdea1` Fix the SourceMod 1.13 return-type errors

| File | Change |
|---|---|
| `movements/grindable-rail.sp` | `CPFRailHandler.OnGameFrame`: `CPFRail` to `void` |
| `pfstate.sp` | `CPFStateController.SetCooldown`: `int` to `void` |

`OnGameFrame`'s only `return` was a bare `return;`, and it otherwise fell off the end; its sole caller in `parkourfortress.sp` discards the result. `SetCooldown` never returned a value at all, and all three callers (`climb.sp`, `vault.sp`, `wallrun.sp`) discard it.

### `70a4f57` Remove the dead CGameMovement methodmap

Deletes `methodmap CGameMovement`, the `CTFGameMovementOffsets` enum struct, and the `offsets` global from `shareddefs.sp`.

This is safe because the methodmap is dead code. It is never instantiated, never referenced outside its own definition, and `offsets.player` is never assigned anywhere, so the getter could only ever have read a zero offset. It looks orphaned by 54119ad ("Move airaccel triggers to extension"), which moved movement hooking out to the Metamod extension.

That left `g_hSDKGetBaseEntity` with no consumer, so this also drops the global and its `CBaseEntity::GetBaseEntity` SDKCall preparation in `InitSDK`.

> **If you want to revive in-plugin movement later:** retyping will not be enough. There is no legal round-trip of a 64-bit address through a 32-bit methodmap cell on x64. The `Address` has to be held in a global or passed explicitly per call, reducing the methodmap to a plain namespace.

## Verification

Compiled from the branch tip with both compilers, linux x86_64:

| Compiler | Errors | Warnings | Output |
|---|---|---|---|
| `spcomp64` 1.13.0-git7415 | **0** | 34 | 119,581 b |
| `spcomp64` 1.12.0-git7246 | **0** | 34 | 122,367 b |

- The two compilers produce **identical warning sets**.
- The warning set is **byte-for-byte identical to `main` before this branch** (34 warnings, none added, none removed). The `g_hSDKGetBaseEntity` warning predicted in #64 does not appear, because this PR removes the global rather than leaving it orphaned.
- No reachable logic is altered. Every change is a return-type narrowing on a value nobody consumed, or deletion of unreferenced code.

## Note on scope

The issue text suggested `TakeDamage_t` in `shareddefs.sp` was also unused and could go in the same pass. **That is wrong** and it is deliberately kept here: `DAMAGE_YES` is live in `roll.sp`, `pfstate.sp`, and `pfclient.sp`. Removing it fails the build on both compilers with `error 017: undefined symbol "DAMAGE_YES"`. I have corrected the claim on #64.
